### PR TITLE
Typo and bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Binary built by using [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBu
 Now it is registered in [JuliaRegisties](https://github.com/JuliaRegistries/General), thus can be installed by running:
 
 ```sh
-(v1.1) pkg> add Libxcs
+(v1.1) pkg> add Libxc
 ```
 
 When wrapping new libxc version, first run `update_functionals_info.jl` to update functionals' info

--- a/src/xc.jl
+++ b/src/xc.jl
@@ -115,7 +115,7 @@ xc_func_end(p::Ptr{XCFuncType}) = ccall( (:xc_func_end, libxc), Cvoid, (Ptr{XCFu
 xc_func_free(p::Ptr{XCFuncType}) = ccall( (:xc_func_free, libxc), Cvoid, (Ptr{XCFuncType},), p)
 xc_func_get_info(p::Ptr{XCFuncType}) = ccall( (:xc_func_get_info, libxc), Ptr{XCFuncInfoType}, (Ref{XCFuncType},), p )
 xc_func_set_dens_threshold(p::Ptr{XCFuncType}, dens_threshold::Float64) = ccall( (:xc_func_set_dens_threshold, libxc), Cvoid, (Ptr{XCFuncType}, Float64), p, dens_threshold)
-xc_func_set_ext_params(p::Ptr{XCFuncType}, ext_params::Ptr{Float64}) = ccall( (:xc_func_set_dens_threshold, libxc), Cvoid, (Ptr{XCFuncType}, Ptr{Float64}), p, ext_params)
+xc_func_set_ext_params(p::Ptr{XCFuncType}, ext_params::Ptr{Float64}) = ccall( (:xc_func_set_ext_params, libxc), Cvoid, (Ptr{XCFuncType}, Ptr{Float64}), p, ext_params)
 
 ######################################################################
 ##  LDA-xc

--- a/src/xc.jl
+++ b/src/xc.jl
@@ -142,7 +142,7 @@ xc_gga!(p::Ptr{XCFuncType}, np::Int,
         rho::Array{Float64, 1}, sigma::Array{Float64, 1},
         zk::Array{Float64, 1}, vrho::Array{Float64, 1}, vsigma::Array{Float64, 1},
         v2rho2::Array{Float64, 1}, v2rhosigma::Array{Float64, 1}, v2sigma2::Array{Float64, 1},
-        v3rho3::Array{Float64, 1}, v3rhosigma::Array{Float64, 1}, v3rhosigma2::Array{Float64, 1}, v3sigma3::Array{Float64, 1}) =
+        v3rho3::Array{Float64, 1}, v3rho2sigma::Array{Float64, 1}, v3rhosigma2::Array{Float64, 1}, v3sigma3::Array{Float64, 1}) =
     ccall( (:xc_gga, libxc), Cvoid, (Ptr{XCFuncType}, Cint,
                                      Ptr{Float64}, Ptr{Float64},
                                      Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
@@ -152,7 +152,7 @@ xc_gga!(p::Ptr{XCFuncType}, np::Int,
                                      rho, sigma,
                                      zk, vrho, vsigma,
                                      v2rho2, v2rhosigma, v2sigma2,
-                                     v3rho3, v3rhosigma, v3rhosigma2, v3sigma3)
+                                     v3rho3, v3rho2sigma, v3rhosigma2, v3sigma3)
 
 xc_gga_exc!(p::Ptr{XCFuncType}, np::Int, rho::Array{Float64, 1}, sigma::Array{Float64, 1},
             zk::Array{Float64, 1}) =


### PR DESCRIPTION
This PR corrects a typo in the README and fixes a copy-and-paste error in `xc.jl`.