### PR TITLE
Functional now stores identifier symbolically

### DIFF
--- a/src/Functional.jl
+++ b/src/Functional.jl
@@ -31,7 +31,7 @@ end
 
 mutable struct Functional
     number::Int
-    name::String
+    identifier::Symbol
     kind::FunctionalKind
     family::FunctionalFamily
     n_spin::Int
@@ -42,12 +42,12 @@ end
 
 
 """
-    Functional(identifier; n_spin::Integer = 1)
+    Functional(identifier::Symbol; n_spin::Integer = 1)
 
 Construct a Functional from a libxc `identifier` and the number
 of spins `n_spin` to consider. `
 """
-function Functional(identifier; n_spin::Integer = 1)
+function Functional(identifier::Symbol; n_spin::Integer = 1)
     if n_spin != 1 && n_spin != 2
         error("n_spin needs to be 1 or 2")
     end
@@ -79,7 +79,7 @@ function Functional(identifier; n_spin::Integer = 1)
         # TODO Extract references ....
 
         # Make functional and attach finalizer for cleaning up the pointer
-        func = Functional(number, string(identifier), FunctionalKind(kind),
+        func = Functional(number, identifier, FunctionalKind(kind),
                           FunctionalFamily(family), n_spin, pointer)
         finalizer(cls -> pointer_cleanup(cls.pointer), func)
         return func

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,11 +52,23 @@ end
     sigma = [0.2, 0.3, 0.4, 0.5, 0.6]
     result = zeros(Float64, 5)
 
+    # LDA
     func = Libxc.Functional(:lda_x)
+    @test func.identifier == :lda_x
+    @test func.number == 1
+    @test func.family == Libxc.family_lda
+    @test func.n_spin == 1
+
     Libxc.evaluate_lda!(func, rho, E=result)
     @test result ≈ [-0.342809, -0.431912, -0.494416, -0.544175, -0.586194] atol=1e-5
 
+    # GGA
     func = Libxc.Functional(:gga_x_pbe)
+    @test func.identifier == :gga_x_pbe
+    @test func.number == 101
+    @test func.family == Libxc.family_gga
+    @test func.n_spin == 1
+
     Libxc.evaluate_gga!(func, rho, sigma, E=result)
     @test result ≈ [-0.452598, -0.478878, -0.520674, -0.561428, -0.598661] atol=1e-5
 end


### PR DESCRIPTION
This PR alters the Functional class in order to store the selected functional as a Symbol, which is faster to handle in Julia.